### PR TITLE
Fix Windows compilation failure of `ppx_base` because of `base` and `ocaml_intrinsics_kernel` symbol clash

### DIFF
--- a/src/conditional_stubs.c
+++ b/src/conditional_stubs.c
@@ -19,8 +19,3 @@ intnat caml_csel_nativeint_unboxed(value v_cond, intnat ifso, intnat ifnot)
 {
   return (Bool_val(v_cond) ? ifso : ifnot);
 }
-
-CAMLprim value caml_csel_value(value v_cond, value v_true, value v_false)
-{
-  return (Bool_val(v_cond) ? v_true : v_false);
-}

--- a/src/csel_value.c
+++ b/src/csel_value.c
@@ -1,0 +1,6 @@
+#include <caml/mlvalues.h>
+
+CAMLprim CAMLweakdef value caml_csel_value(value v_cond, value v_true, value v_false)
+{
+    return (Bool_val(v_cond) ? v_true : v_false);
+}

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (foreign_stubs
   (language c)
-  (names conditional_stubs int_stubs float_stubs))
+  (names conditional_stubs int_stubs float_stubs csel_value))
  (name ocaml_intrinsics_kernel)
  (public_name ocaml_intrinsics_kernel)
  (libraries)


### PR DESCRIPTION
Put `CAMLweakdef` function in its own translation unit for Windows compatibility, or it conflicts with other non-weakdef symbols with the same name from other libraries. There's a conflicting symbol in `base` at: https://github.com/janestreet/base/blob/b6430a41ba658335aaeff796b37c10b1d1803637/src/int_math_stubs.c#L198-L201.

```console
$ dune build
File "bin/dune", line 3, characters 8-12:
3 |  (names main)
            ^^^^
/usr/lib/gcc/x86_64-w64-mingw32/11/../../../../x86_64-w64-mingw32/bin/ld: C:\Users\Antonin\AppData\Local\opam\default\lib\ocaml_intrinsics_kernel\libocaml_intrinsics_kernel_stubs.a(conditional_stubs.o):/cygdrive/c/Users/Antonin/AppData/Local/opam/default/.opam-switch/build/ocaml_intrinsics_kernel.v0.17.0/_build/default/src/conditional_stubs.c:16: multiple definition of `caml_csel_value'; C:\Users\Antonin\AppData\Local\opam\default\lib\base\libbase_stubs.a(int_math_stubs.o):/cygdrive/c/Users/Antonin/AppData/Local/opam/default/.opam-switch/build/base.v0.17.0/_build/default/src/int_math_stubs.c:200: first defined here
collect2: error: ld returned 1 exit status
** Fatal error: Error during linking
```

Also note that the `caml_` prefix for C symbols is reserved by the OCaml runtime. I suggest JS libraries pick another prefix.