### PR TITLE
Do not require SSE4.1 for SSE2 instructions

### DIFF
--- a/src/float_stubs.c
+++ b/src/float_stubs.c
@@ -4,12 +4,12 @@
 #include <caml/alloc.h>
 #include <caml/mlvalues.h>
 
-#if defined(__SSE4_1__) || defined(_MSC_VER)
+#if defined(__SSE2__) || defined(_MSC_VER)
 
 #ifdef _MSC_VER
 #include <intrin.h>
 #else // _MSC_VER
-#include <smmintrin.h>
+#include <emmintrin.h>
 #endif // _MSC_VER
 
 double caml_sse2_float64_min(double x, double y)
@@ -22,7 +22,7 @@ double caml_sse2_float64_max(double x, double y)
   return _mm_cvtsd_f64(_mm_max_sd(_mm_set_sd(x), _mm_set_sd(y)));
 }
 
-#else // __SSE4_1__ || _MSC_VER
+#else // __SSE2__ || _MSC_VER
 
 #include <math.h>
 
@@ -38,7 +38,7 @@ double caml_sse2_float64_max(double x, double y) {
   return x > y ? x : y;
 }
 
-#endif // __SSE4_1__
+#endif // __SSE2__
 
 CAMLprim value caml_sse2_float64_min_bytecode(value x, value y)
 {


### PR DESCRIPTION
Every `x86_64` CPU, from the very first one made, supports SSE2.  SSE4.1, on the other hand, is not supported by all `x86_64` CPUs currently in use, and is not needed for these functions.